### PR TITLE
Feature/default type

### DIFF
--- a/cwlavro-tools/src/main/java/io/cwl/avro/CWL.java
+++ b/cwlavro-tools/src/main/java/io/cwl/avro/CWL.java
@@ -34,6 +34,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
@@ -375,10 +376,24 @@ public class CWL {
                 final Object o = sequenceSafeGson.fromJson(jsonElement, c);
                 // hack to transfer over defaults
                 if (jsonElement instanceof JsonObject && ((JsonObject)jsonElement).has("default")) {
-                    final JsonPrimitive defaultValue = ((JsonObject)jsonElement).getAsJsonPrimitive("default");
-                    if (o instanceof CommandInputParameter) {
-                        String defaultVal = defaultValue.toString().replaceAll("^\"|\"$", "");
-                        ((CommandInputParameter)o).setDefault$(defaultVal);
+                    JsonElement defaultJsonElement = ((JsonObject)jsonElement).get("default");
+                    if (defaultJsonElement instanceof JsonObject) {
+                        final JsonObject defaultValue = ((JsonObject) jsonElement).getAsJsonObject("default");
+                        if (o instanceof CommandInputParameter) {
+                            ((CommandInputParameter)o).setDefault$(defaultValue);
+                        }
+                    }
+                    if (defaultJsonElement instanceof JsonPrimitive) {
+                        final JsonPrimitive defaultValue = ((JsonObject) jsonElement).getAsJsonPrimitive("default");
+                        if (o instanceof CommandInputParameter){
+                            String defaultVal= defaultValue.toString().replaceAll("^\"|\"$", "");
+                            ((CommandInputParameter)o).setDefault$(defaultVal);
+                        }
+                    }
+                    if (defaultJsonElement instanceof JsonNull) {
+                        if (o instanceof CommandInputParameter){
+                            ((CommandInputParameter)o).setDefault$(null);
+                        }
                     }
                 }
 

--- a/cwlavro-tools/src/test/java/AbstractClientTest.java
+++ b/cwlavro-tools/src/test/java/AbstractClientTest.java
@@ -83,8 +83,7 @@ public abstract class AbstractClientTest {
         final URL resource = Resources.getResource("cwl.json");
         final CWL cwl = getCWL();
         final ImmutablePair<String, String> output = cwl.parseCWL(resource.getFile());
-        assertTrue(!output.getLeft().isEmpty() && output.getLeft().contains("cwlVersion"));
-        assertTrue(output.getRight().contains("cwltool") || output.getRight().isEmpty());
+        checkOutput(output);
     }
 
     /**
@@ -96,8 +95,15 @@ public abstract class AbstractClientTest {
         final URL resource = Resources.getResource("valid.cwl");
         final CWL cwl = getCWL();
         final ImmutablePair<String, String> output = cwl.parseCWL(resource.getFile());
-        assertTrue(!output.getLeft().isEmpty() && output.getLeft().contains("cwlVersion"));
-        assertTrue(output.getRight().contains("cwltool") || output.getRight().isEmpty());
+        checkOutput(output);
+    }
+
+    private void checkOutput(ImmutablePair<String, String> output) {
+        String left = output.getLeft();
+        String right = output.getRight();
+        assertTrue("Expected output.getLeft() to not be empty.", !left.isEmpty());
+        assertTrue("Expected output.getLeft() to contain 'cwlVersion' but got " + left, left.contains("cwlVersion"));
+        assertTrue("Expected output.getRight() to be empty or contain 'cwltool' but got " + right, right.contains("cwltool") || right.isEmpty());
     }
 
     /**
@@ -110,8 +116,7 @@ public abstract class AbstractClientTest {
         Gson gson = CWL.getTypeSafeCWLToolDocument();
         final URL resource = Resources.getResource("nullDefault.cwl");
         final ImmutablePair<String, String> output = cwl.parseCWL(resource.getFile());
-        assertTrue(!output.getLeft().isEmpty() && output.getLeft().contains("cwlVersion"));
-        assertTrue(output.getRight().contains("cwltool") || output.getRight().isEmpty());
+        checkOutput(output);
         final String stringStringImmutablePair = output.getLeft();
         Object cwlObject;
         try {

--- a/cwlavro-tools/src/test/java/AbstractClientTest.java
+++ b/cwlavro-tools/src/test/java/AbstractClientTest.java
@@ -17,6 +17,7 @@
 
 import com.google.common.io.Resources;
 import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
 import io.cwl.avro.CWL;
 import io.cwl.avro.CommandLineTool;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -97,6 +98,28 @@ public abstract class AbstractClientTest {
         final ImmutablePair<String, String> output = cwl.parseCWL(resource.getFile());
         assertTrue(!output.getLeft().isEmpty() && output.getLeft().contains("cwlVersion"));
         assertTrue(output.getRight().contains("cwltool") || output.getRight().isEmpty());
+    }
+
+    /**
+     * This tests if gson can parse a tool with an input parameter that has something like 'default: null'
+     * @throws Exception
+     */
+    @Test
+    public void testNullDefault() throws Exception {
+        final CWL cwl = getCWL();
+        Gson gson = CWL.getTypeSafeCWLToolDocument();
+        final URL resource = Resources.getResource("nullDefault.cwl");
+        final ImmutablePair<String, String> output = cwl.parseCWL(resource.getFile());
+        assertTrue(!output.getLeft().isEmpty() && output.getLeft().contains("cwlVersion"));
+        assertTrue(output.getRight().contains("cwltool") || output.getRight().isEmpty());
+        final String stringStringImmutablePair = output.getLeft();
+        Object cwlObject;
+        try {
+            cwlObject = gson.fromJson(stringStringImmutablePair, CommandLineTool.class);
+
+        } catch (JsonParseException ex) {
+            ex.printStackTrace();
+        }
     }
 
     /**

--- a/cwlavro-tools/src/test/java/AbstractClientTest.java
+++ b/cwlavro-tools/src/test/java/AbstractClientTest.java
@@ -103,7 +103,7 @@ public abstract class AbstractClientTest {
         String right = output.getRight();
         assertTrue("Expected output.getLeft() to not be empty.", !left.isEmpty());
         assertTrue("Expected output.getLeft() to contain 'cwlVersion' but got " + left, left.contains("cwlVersion"));
-        assertTrue("Expected output.getRight() to be empty or contain 'cwltool' but got " + right, right.contains("cwltool") || right.isEmpty());
+        assertTrue("Expected output.getRight() to be empty or contain 'cwltool' or 'Picked up _JAVA_OPTIONS: -Xmx2048m -Xms512m' but got " + right, right.contains("cwltool") || right.isEmpty() || right.contains("Picked up"));
     }
 
     /**

--- a/cwlavro-tools/src/test/resources/nullDefault.cwl
+++ b/cwlavro-tools/src/test/resources/nullDefault.cwl
@@ -1,0 +1,133 @@
+#!/usr/bin/env cwl-runner
+
+class: CommandLineTool
+
+id: "cgpmap"
+
+label: "CGP BWA-mem mapping flow"
+
+cwlVersion: v1.0
+
+doc: |
+    ![build_status](https://quay.io/repository/wtsicgp/dockstore-cgpmap/status)
+    A Docker container for the CGP BWA-mem mapping flow. See the [dockstore-cgpmap](https://github.com/cancerit/dockstore-cgpmap) website for more information.
+
+dct:creator:
+  "@id": "http://orcid.org/0000-0002-5634-1539"
+  foaf:name: Keiran M Raine
+  foaf:mbox: "keiranmraine@gmail.com"
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: "quay.io/wtsicgp/dockstore-cgpmap:1.0.4"
+
+hints:
+  - class: ResourceRequirement
+    coresMin: 1 # works but long, 8 recommended
+    ramMin: 15000 # good for WGS human ~30-60x
+    outdirMin: 5000000 # unlikely any BAM processing would be possible in less
+
+inputs:
+  reference:
+    type: File
+    doc: "The core reference (fa, fai, dict) as tar.gz"
+    inputBinding:
+      prefix: -reference
+      position: 1
+      separate: true
+
+  bwa_idx:
+    type: File
+    doc: "The BWA indexes in tar.gz"
+    inputBinding:
+      prefix: -bwa_idx
+      position: 2
+      separate: true
+
+  filename:
+    type:
+      - "null"
+      - string
+    inputBinding:
+      position: 90
+      valueFrom: null
+    default: null
+    doc: |
+      Generates default output filename on the base of filelist/filelist_mates files
+      
+  sample:
+    type: string
+    doc: "Sample name to be included in output [B|CR]AM header, also used to name final file"
+    inputBinding:
+      prefix: -sample
+      position: 3
+      separate: true
+
+  scramble:
+    type: string?
+    doc: "Options to pass to scramble when generating CRAM output, see scramble docs"
+    default: ''
+    inputBinding:
+      prefix: -scramble
+      position: 4
+      separate: true
+      shellQuote: true
+
+  bwa:
+    type: string?
+    default: ' -Y -K 100000000'
+    doc: "Mapping and output parameters to pass to BWA-mem, see BWA docs, default ' -Y -K 100000000'"
+    inputBinding:
+      prefix: -bwa
+      position: 5
+      separate: true
+      shellQuote: false
+
+  cram:
+    type: boolean
+    doc: "Set if output should be in CRAM format instead of BAM, see 'scramble' for tuning parameters."
+    inputBinding:
+      prefix: -cram
+      position: 6
+
+  bams_in:
+    type:
+    - 'null'
+    - type: array
+      items: File
+    doc: "Can be BAM, CRAM, fastq (paired or interleaved), BAM/CRAM can be mixed together but not FASTQ."
+    inputBinding:
+      position: 7
+
+outputs:
+  out_bam:
+    type: File
+    outputBinding:
+      glob: $(inputs.sample).bam
+
+  out_bai:
+    type: File
+    outputBinding:
+      glob: $(inputs.sample).bam.bai
+
+  out_bas:
+    type: File
+    outputBinding:
+      glob: $(inputs.sample).bam.bas
+
+  out_md5:
+    type: File
+    outputBinding:
+      glob: $(inputs.sample).bam.md5
+
+  out_met:
+    type: File
+    outputBinding:
+      glob: $(inputs.sample).bam.met
+
+  out_maptime:
+    type: File
+    outputBinding:
+      glob: $(inputs.sample).bam.maptime
+
+baseCommand: ["/opt/wtsi-cgp/bin/ds-wrapper.pl"]


### PR DESCRIPTION
Currently, Gson can't convert from json properly for a CWL tool correctly when there is a 'default: null' in one of the input parameters.  This pull requests introduces several things:

- Handle this null value
- Create a test to test for when there is this null value
- Simplify and increase verbosity of all the tests

Additionally there is a small edit to get the Travis test to work.  For some reason in the bunny test, `Picked up _JAVA_OPTIONS: -Xmx2048m -Xms512m` was returned instead of an empty string for output.getRight().  It appears the Travis environment changed, and instead of 

```
$ java -Xmx32m -version
java version "1.8.0_131"
```
it is
```
$ java -Xmx32m -version
Picked up _JAVA_OPTIONS: -Xmx2048m -Xms512m
java version "1.8.0_144"
```